### PR TITLE
Fix a panic and change designer new url

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -179,7 +179,7 @@ func doAll(c *cli.Context) {
 	go loader.GetPHFeed(ph)
 	go loader.GetRedditFeed(re)
 	go loader.GetRssFeed("HackerNews", "https://news.ycombinator.com/rss", hn)
-	go loader.GetRdfFeedWithDesc("Github Trends", "http://github-trends.ryotarai.info/rss/github_trends_all_daily.rss", gh)
+	go loader.GetRssFeedWithDesc("Github Trends", "http://github-trends.ryotarai.info/rss/github_trends_all_daily.rss", gh)
 	go loader.GetRssFeed("TechCrunch", "http://feeds.feedburner.com/TechCrunch/", tc)
 	go loader.GetRssFeed("Mashable", "http://feeds.mashable.com/Mashable", ms)
 	go loader.GetRssFeed("The Next Web", "http://feeds2.feedburner.com/thenextweb", tnw)
@@ -229,7 +229,7 @@ func doHack(c *cli.Context) {
 	ejs := make(chan loader.ResultData)
 	go loader.GetRedditFeed(re)
 	go loader.GetRssFeed("HackerNews", "https://news.ycombinator.com/rss", hn)
-	go loader.GetRdfFeedWithDesc("Github Trends", "http://github-trends.ryotarai.info/rss/github_trends_all_daily.rss", gh)
+	go loader.GetRssFeedWithDesc("Github Trends", "http://github-trends.ryotarai.info/rss/github_trends_all_daily.rss", gh)
 	go loader.GetRssFeed("EchoJS", "http://www.echojs.com/rss", ejs)
 	reres := <-re
 	hnres := <-hn

--- a/commands.go
+++ b/commands.go
@@ -183,7 +183,7 @@ func doAll(c *cli.Context) {
 	go loader.GetRssFeed("TechCrunch", "http://feeds.feedburner.com/TechCrunch/", tc)
 	go loader.GetRssFeed("Mashable", "http://feeds.mashable.com/Mashable", ms)
 	go loader.GetRssFeed("The Next Web", "http://feeds2.feedburner.com/thenextweb", tnw)
-	go loader.GetRssFeed("Designer News", "https://news.layervault.com/?format=rss", dn)
+	go loader.GetRssFeed("Designer News", "https://www.designernews.co/?format=rss", dn)
 	go loader.GetRssFeed("Forbes - Tech", "http://www.forbes.com/technology/feed/", fbs)
 	go loader.GetRssFeed("EchoJS", "http://www.echojs.com/rss", ejs)
 	go loader.GetRssFeed("A16Z", "http://a16z.com/feed/", a16z)
@@ -282,7 +282,7 @@ func doTNW(c *cli.Context) {
 }
 
 func doDN(c *cli.Context) {
-	displayUnitRssFeed("Designer News", "https://news.layervault.com/?format=rss")
+	displayUnitRssFeed("Designer News", "https://www.designernews.co/?format=rss")
 }
 
 func doFB(c *cli.Context) {


### PR DESCRIPTION
Hi ✋  I fixed two issues.

First, I changed the function that takes GitHub Trends from `GetRdfFeedWithDesc` to `GetRssFeedWithDesc` because in my environment panic occurred when `GetRdfFeedWithDesc` was used.

```
[wlan3890.u-aizu.ac.jp]% ts pop
.___________. _______   ______  __    __       _______..___________.     ___        ______  __  ___
|           ||   ____| /      ||  |  |  |     /       ||           |    /   \      /      ||  |/  /
`---|  |----`|  |__   |  ,----'|  |__|  |    |   (----``---|  |----`   /  ^  \    |  ,----'|  '  /
    |  |     |   __|  |  |     |   __   |     \   \        |  |       /  /_\  \   |  |     |    <
    |  |     |  |____ |  `----.|  |  |  | .----)   |       |  |      /  _____  \  |  `----.|  .  \
    |__|     |_______| \______||__|  |__| |_______/        |__|     /__/     \__\  \______||__|\__\



panic: expected element type <RDF> but have <rss>

goroutine 23 [running]:
panic(0x338740, 0xc420013e10)
        /usr/local/Cellar/go/1.7.3/libexec/src/runtime/panic.go:500 +0x1a1
github.com/timakin/ts/loader.perror(0x5242e0, 0xc420013e10)
        /Users/upamune/src/github.com/timakin/ts/loader/common.go:18 +0x5c
github.com/timakin/ts/loader.getRDFDataFromUrl(0x3b20c0, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/upamune/src/github.com/timakin/ts/loader/rss.go:56 +0x170
github.com/timakin/ts/loader.GetRdfFeedWithDesc(0x3a3947, 0xd, 0x3b20c0, 0x42, 0xc42007a720)
        /Users/upamune/src/github.com/timakin/ts/loader/rss.go:103 +0x6e
created by main.doAll
        /Users/upamune/src/github.com/timakin/ts/commands.go:182 +0x29a


[wlan3890.u-aizu.ac.jp]% ts hack
panic: expected element type <RDF> but have <rss>

goroutine 7 [running]:
panic(0x338740, 0xc42042be80)
        /usr/local/Cellar/go/1.7.3/libexec/src/runtime/panic.go:500 +0x1a1
github.com/timakin/ts/loader.perror(0x5242e0, 0xc42042be80)
        /Users/upamune/src/github.com/timakin/ts/loader/common.go:18 +0x5c
github.com/timakin/ts/loader.getRDFDataFromUrl(0x3b20c0, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/upamune/src/github.com/timakin/ts/loader/rss.go:56 +0x170
github.com/timakin/ts/loader.GetRdfFeedWithDesc(0x3a3947, 0xd, 0x3b20c0, 0x42, 0xc42001a5a0)
        /Users/upamune/src/github.com/timakin/ts/loader/rss.go:103 +0x6e
created by main.doHack
        /Users/upamune/src/github.com/timakin/ts/commands.go:232 +0x178
```

Second, I changed the URL of DesinerNews to a new URL.

```
[wlan3890.u-aizu.ac.jp]% ts dn
[Designer News]
panic: Get https://news.layervault.com/?format=rss: dial tcp 54.231.81.66:443: i/o timeout

goroutine 1 [running]:
panic(0x34ffc0, 0xc4200fe180)
        /usr/local/Cellar/go/1.7.3/libexec/src/runtime/panic.go:500 +0x1a1
github.com/timakin/ts/loader.perror(0x5237a0, 0xc4200fe180)
        /Users/upamune/src/github.com/timakin/ts/loader/common.go:18 +0x5c
github.com/timakin/ts/loader.GetUnitRssFeed(0x3ad4b6, 0x27)
        /Users/upamune/src/github.com/timakin/ts/loader/rss.go:132 +0x8b
main.displayUnitRssFeed(0x3a3913, 0xd, 0x3ad4b6, 0x27)
        /Users/upamune/src/github.com/timakin/ts/commands.go:158 +0xa6
main.doDN(0xc4200a0780)
        /Users/upamune/src/github.com/timakin/ts/commands.go:285 +0x4b
github.com/codegangsta/cli.HandleAction(0x326c80, 0x3d8638, 0xc4200a0780, 0xc42001a400, 0x0)
        /Users/upamune/src/github.com/codegangsta/cli/app.go:485 +0x61
github.com/codegangsta/cli.Command.Run(0x39ffee, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/upamune/src/github.com/codegangsta/cli/command.go:198 +0xcfb
github.com/codegangsta/cli.(*App).Run(0xc42008eb60, 0xc42000c660, 0x2, 0x2, 0x0, 0x0)
        /Users/upamune/src/github.com/codegangsta/cli/app.go:245 +0x723
main.main()
        /Users/upamune/src/github.com/timakin/ts/ts.go:18 +0xf5
```

FYI
```
[wlan3890.u-aizu.ac.jp]% uname -a
Darwin wlan3890.u-aizu.ac.jp 15.6.0 Darwin Kernel Version 15.6.0: Mon Aug 29 20:21:34 PDT 2016; root:xnu-3248.60.11~1/RELEASE_X86_64 x86_64
```


Thanks.